### PR TITLE
feat: 쿠폰 시스템 도메인 엔티티 설계

### DIFF
--- a/src/main/java/com/jhkhub/coupon/entity/Coupon.java
+++ b/src/main/java/com/jhkhub/coupon/entity/Coupon.java
@@ -1,0 +1,40 @@
+package com.jhkhub.coupon.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DiscountType discountType;
+
+    @Column(nullable = false)
+    private Integer discountValue;
+
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endAt;
+
+    @Column(nullable = false)
+    private LocalDateTime validUntil;
+
+    @OneToOne(mappedBy = "coupon")
+    private CouponStock couponStock;
+
+}

--- a/src/main/java/com/jhkhub/coupon/entity/CouponIssue.java
+++ b/src/main/java/com/jhkhub/coupon/entity/CouponIssue.java
@@ -1,0 +1,31 @@
+package com.jhkhub.coupon.entity;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponIssue {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_issue_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDateTime issuedAt;
+
+    private LocalDateTime usedAt;
+}

--- a/src/main/java/com/jhkhub/coupon/entity/CouponStock.java
+++ b/src/main/java/com/jhkhub/coupon/entity/CouponStock.java
@@ -1,0 +1,23 @@
+package com.jhkhub.coupon.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Cleanup;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CouponStock {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coupon_stock_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @Column(nullable = false)
+    private Integer totalQuantity;
+
+}

--- a/src/main/java/com/jhkhub/coupon/entity/DiscountType.java
+++ b/src/main/java/com/jhkhub/coupon/entity/DiscountType.java
@@ -1,0 +1,5 @@
+package com.jhkhub.coupon.entity;
+
+public enum DiscountType {
+    PERCENT, AMOUNT
+}

--- a/src/main/java/com/jhkhub/coupon/entity/User.java
+++ b/src/main/java/com/jhkhub/coupon/entity/User.java
@@ -1,0 +1,17 @@
+package com.jhkhub.coupon.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String loginId;
+}


### PR DESCRIPTION
- User: 사용자 정보
- Coupon: 쿠폰 정보
- CouponStock: 쿠폰 수량 관리
- CouponIssue: 쿠폰 발급 이력

복잡도를 줄이기 위해 이번엔 Coupon 엔티티에 validUntil (만료일) 하나만 두고 진행 -> 절대 기간만 사용

절대 기간: "무조건 12월 31일까지 사용 가능"
상대 기간: "발급받은 순간부터 3일간 사용 가능"

Resolves #8 